### PR TITLE
docs(README): add Arazzo 1.1.0 to supported spec versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It supports Runtime Expressions defined in following Arazzo specification versio
 
 - [Arazzo 1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html)
 - [Arazzo 1.0.1](https://spec.openapis.org/arazzo/v1.0.1.html)
+- [Arazzo 1.1.0](https://spec.openapis.org/arazzo/v1.1.0.html)
 
 <table>
   <tr>


### PR DESCRIPTION
## Summary

- Add **Arazzo 1.1.0** to the list of supported specification versions in the README.

The runtime expression grammar shipped in #116 implements the Arazzo 1.1.0 changes (inlined reference grammars, `$self`, `$inputs`/`$outputs` JSON Pointer support) per the merged [OAI/Arazzo-Specification#454](https://github.com/OAI/Arazzo-Specification/pull/454). This documents that 1.1.0 is now supported. Link verified live (`https://spec.openapis.org/arazzo/v1.1.0.html`).

## Test plan

- [x] Docs-only change; link target returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)