### PR TITLE
ci: use DEPENDABOT_TOKEN for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -18,7 +18,7 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@v3
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.DEPENDABOT_TOKEN }}"
 
       - name: Check if auto-merge applicable
         id: check
@@ -35,18 +35,18 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Wait for checks to pass
         if: steps.check.outputs.should_merge == 'true'
         run: gh pr checks "$PR_URL" --watch --required --fail-fast
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Squash and merge
         if: steps.check.outputs.should_merge == 'true'
         run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
## Summary
Switches the dependabot auto-merge workflow from the default `GITHUB_TOKEN` to a dedicated `DEPENDABOT_TOKEN` PAT across all four token references (metadata fetch + approve/wait/merge steps).

## Why
- `GITHUB_TOKEN`-driven merges/pushes **do not trigger** downstream workflows; a PAT does.
- A distinct token identity can satisfy branch-protection review/approval requirements that `GITHUB_TOKEN` may not.

## Prerequisite
A `DEPENDABOT_TOKEN` repo secret must be configured (PAT with contents + pull-requests write). Without it, all steps will fail on auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)