### PR TITLE
feat: add interpolate for string template transclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [Arazzo Runtime Expressions](https://spec.openapis.org/arazzo/latest.html#runtime-expressions) allows values to be defined based on information that will be available within the HTTP message in an actual API call,
 or within objects serialized from the Arazzo document such as [workflows](https://spec.openapis.org/arazzo/latest.html#workflow-object) or [steps](https://spec.openapis.org/arazzo/latest.html#step-object).
 
-`@swaggerexpert/arazzo-runtime-expression` is a **parser**, **validator** and **extractor** for Arazzo Runtime Expressions.
+`@swaggerexpert/arazzo-runtime-expression` is a **parser**, **validator**, **extractor** and **interpolator** for Arazzo Runtime Expressions.
 
 It supports Runtime Expressions defined in following Arazzo specification versions:
 
@@ -37,6 +37,7 @@ It supports Runtime Expressions defined in following Arazzo specification versio
   - [Installation](#installation)
   - [Usage](#usage)
     - [Extraction](#extraction)
+    - [Interpolation](#interpolation)
     - [Parsing](#parsing)
       - [Translators](#translators)
       - [Statistics](#statistics)
@@ -60,7 +61,7 @@ You can install `@swaggerexpert/arazzo-runtime-expression` using `npm`:
 
 ### Usage
 
-`@swaggerexpert/arazzo-runtime-expression` currently supports **extraction**, **parsing** and **validation**.
+`@swaggerexpert/arazzo-runtime-expression` currently supports **extraction**, **interpolation**, **parsing** and **validation**.
 Both parser and validator are based on a superset of [ABNF](https://www.rfc-editor.org/rfc/rfc5234) ([SABNF](https://cs.github.com/ldthomas/apg-js2/blob/master/SABNF.md))
 and use [apg-lite](https://github.com/ldthomas/apg-lite) parser generator.
 
@@ -88,6 +89,49 @@ const expressions = extract('{$url}');
 test(expressions[0]); // => true
 parse(expressions[0]); // => { result, tree }
 ```
+
+#### Interpolation
+
+Arazzo embeds Runtime Expressions into string values surrounded with `{}` curly braces (a mechanism known as [transclusion](https://en.wikipedia.org/wiki/Transclusion)).
+To render such a template string, use the **interpolate** function. It replaces every `{expression}`
+occurrence with a value produced by a **resolver** callback, while preserving all literal content.
+
+Because this package is a parser and has no knowledge of the runtime context (HTTP messages, workflow
+inputs/outputs, etc.), you supply the resolution logic through the `resolver` callback. The callback
+receives the raw expression (e.g. `$inputs.name`) and returns its value.
+
+```js
+import { interpolate } from '@swaggerexpert/arazzo-runtime-expression';
+
+// Single expression
+interpolate('Hello {$inputs.name}!', () => 'world'); // => 'Hello world!'
+
+// Multiple expressions resolved from a lookup table
+const values = { '$inputs.clientId': 'abc', '$inputs.grantType': 'authorization_code' };
+interpolate('client_id={$inputs.clientId}&grant_type={$inputs.grantType}', (expression) => values[expression]);
+// => 'client_id=abc&grant_type=authorization_code'
+
+// Strings without expressions are returned unchanged
+interpolate('no expressions here', () => 'X'); // => 'no expressions here'
+```
+
+Resolved values are stringified before being spliced into the template. The default stringification
+renders `undefined` and `null` as an empty string, uses strings as-is, serializes objects with
+`JSON.stringify` and coerces everything else via `String()`. This can be customized via the
+`stringify` option.
+
+```js
+import { interpolate } from '@swaggerexpert/arazzo-runtime-expression';
+
+interpolate('{$request.body}', () => ({ id: 1 }), {
+  stringify: (value) => JSON.stringify(value, null, 2),
+});
+// => '{\n  "id": 1\n}'
+```
+
+> **Note:** Just like [extraction](#extraction), `$request.body` and `$response.body` expressions
+> containing JSON Pointers with `}` characters cannot be reliably interpolated from the embedded
+> `{expression}` syntax. See the extraction notes for details.
 
 #### Parsing
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ parse(expressions[0]); // => { result, tree }
 
 #### Interpolation
 
-Arazzo embeds Runtime Expressions into string values surrounded with `{}` curly braces (a mechanism known as [transclusion](https://en.wikipedia.org/wiki/Transclusion)).
+Arazzo embeds Runtime Expressions into string values surrounded with `{}` curly braces.
 To render such a template string, use the **interpolate** function. It replaces every `{expression}`
 occurrence with a value produced by a **resolver** callback, while preserving all literal content.
 
@@ -128,10 +128,6 @@ interpolate('{$request.body}', () => ({ id: 1 }), {
 });
 // => '{\n  "id": 1\n}'
 ```
-
-> **Note:** Just like [extraction](#extraction), `$request.body` and `$response.body` expressions
-> containing JSON Pointers with `}` characters cannot be reliably interpolated from the embedded
-> `{expression}` syntax. See the extraction notes for details.
 
 #### Parsing
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ export { default as Grammar } from './grammar.js';
 
 export { default as extract } from './extract.js';
 
+export { default as interpolate } from './interpolate.js';
+
 export { default as parse } from './parse/index.js';
 export { default as CSTTranslator } from './parse/translators/CSTTranslator.js';
 export { default as XMLTranslator } from './parse/translators/XMLTranslator.js';

--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -14,7 +14,9 @@ const grammar = new Grammar();
 const defaultStringify = (value) => {
   if (value === undefined || value === null) return '';
   if (typeof value === 'string') return value;
-  if (typeof value === 'object') return JSON.stringify(value);
+  // JSON.stringify returns undefined for values it cannot serialize
+  // (e.g. an object whose toJSON() returns undefined); coalesce to ''.
+  if (typeof value === 'object') return JSON.stringify(value) ?? '';
   return String(value);
 };
 
@@ -57,10 +59,16 @@ const interpolate = (template, resolver, { stringify = defaultStringify } = {}) 
   // Rebuild the string from the CST, substituting embedded-expression nodes
   // with their resolved and stringified values.
   for (const node of cst.children || []) {
-    if (node.type === 'embedded-expression') {
-      const exprNode = node.children.find((child) => child.type === 'expression');
+    const exprNode =
+      node.type === 'embedded-expression'
+        ? node.children.find((child) => child.type === 'expression')
+        : undefined;
+
+    if (exprNode) {
       output += stringify(resolver(exprNode.text));
     } else {
+      // literal-char, or a defensive fallback should the CST ever lack the
+      // expected expression child - emit the node text verbatim.
       output += node.text;
     }
   }

--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -1,0 +1,71 @@
+import { Parser } from 'apg-lite';
+
+import Grammar from './grammar.js';
+import CSTTranslator from './parse/translators/CSTTranslator.js';
+
+const grammar = new Grammar();
+
+/**
+ * Default stringification of a resolved value.
+ *
+ * `undefined` and `null` become an empty string, strings are used as-is,
+ * objects are serialized as JSON and everything else is coerced via String().
+ */
+const defaultStringify = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+/**
+ * Interpolate (transclude) runtime expressions embedded in a template string.
+ *
+ * Every `{expression}` occurrence is replaced by the value returned from the
+ * `resolver` callback, stringified via `stringify`. Literal characters are
+ * preserved verbatim. When the template cannot be parsed as an
+ * expression-string (e.g. it contains unbalanced `{`/`}`), it is returned
+ * unchanged, mirroring the leniency of `extract`.
+ *
+ * @example
+ *
+ * interpolate('Hello {$inputs.name}!', () => 'world');
+ * // => 'Hello world!'
+ *
+ * interpolate('id={$inputs.id}&name={$inputs.name}', (expression) => values[expression]);
+ * // => 'id=42&name=Alice'
+ */
+const interpolate = (template, resolver, { stringify = defaultStringify } = {}) => {
+  if (typeof template !== 'string') {
+    throw new TypeError('Template must be a string');
+  }
+  if (typeof resolver !== 'function') {
+    throw new TypeError('Resolver must be a function');
+  }
+
+  const parser = new Parser();
+  parser.ast = new CSTTranslator();
+  const result = parser.parse(grammar, 'expression-string', template);
+
+  if (!result.success) {
+    return template;
+  }
+
+  const cst = parser.ast.getTree();
+  let output = '';
+
+  // Rebuild the string from the CST, substituting embedded-expression nodes
+  // with their resolved and stringified values.
+  for (const node of cst.children || []) {
+    if (node.type === 'embedded-expression') {
+      const exprNode = node.children.find((child) => child.type === 'expression');
+      output += stringify(resolver(exprNode.text));
+    } else {
+      output += node.text;
+    }
+  }
+
+  return output;
+};
+
+export default interpolate;

--- a/test/interpolate.js
+++ b/test/interpolate.js
@@ -31,6 +31,26 @@ describe('interpolate', function () {
     assert.strictEqual(result, 'prefixXsuffix');
   });
 
+  it('should replace every occurrence of a repeated expression', function () {
+    const result = interpolate('{$outputs.token}-{$outputs.token}', () => 'abc');
+    assert.strictEqual(result, 'abc-abc');
+  });
+
+  it('should not interpret replacement patterns in a resolved value', function () {
+    // A naive String.prototype.replace would interpret `$&`, `$1`, etc. in the
+    // replacement. The CST walk splices the value verbatim, so it must not.
+    const result = interpolate('x={$inputs.v}', () => 'A$&B');
+    assert.strictEqual(result, 'x=A$&B');
+  });
+
+  it('should not re-interpolate a resolved value that looks like an expression', function () {
+    // A resolved value that itself looks like an embedded expression must never
+    // be re-scanned - the single CST pass guarantees this.
+    const values = { '$inputs.a': '{$inputs.b}', '$inputs.b': 'X' };
+    const result = interpolate('{$inputs.a}{$inputs.b}', (expression) => values[expression]);
+    assert.strictEqual(result, '{$inputs.b}X');
+  });
+
   it('should return string with no expressions unchanged', function () {
     assert.strictEqual(interpolate('no expressions here', () => 'X'), 'no expressions here');
   });
@@ -90,6 +110,16 @@ describe('interpolate', function () {
     assert.strictEqual(interpolate('text with } in it', () => 'X'), 'text with } in it');
     assert.strictEqual(interpolate('{invalid}', () => 'X'), '{invalid}');
     assert.strictEqual(interpolate('{{$url}}', () => 'X'), '{{$url}}');
+  });
+
+  it('should leave a braced literal that is not an expression unchanged', function () {
+    // A JSON-object-looking brace segment makes the whole expression-string fail
+    // to parse, so the template is returned as-is.
+    assert.strictEqual(interpolate('{"a":1}', () => 'X'), '{"a":1}');
+    assert.strictEqual(
+      interpolate('{"x":1}-{$inputs.username}', () => 'X'),
+      '{"x":1}-{$inputs.username}',
+    );
   });
 
   it('should throw for non-string template', function () {

--- a/test/interpolate.js
+++ b/test/interpolate.js
@@ -1,0 +1,104 @@
+import { assert } from 'chai';
+
+import { interpolate } from '../src/index.js';
+
+describe('interpolate', function () {
+  it('should interpolate a single expression', function () {
+    const result = interpolate('Hello {$inputs.name}!', () => 'world');
+    assert.strictEqual(result, 'Hello world!');
+  });
+
+  it('should pass the raw expression to the resolver', function () {
+    const seen = [];
+    interpolate('{$url}{$method}', (expression) => {
+      seen.push(expression);
+      return '';
+    });
+    assert.deepEqual(seen, ['$url', '$method']);
+  });
+
+  it('should interpolate multiple expressions', function () {
+    const values = { '$inputs.clientId': 'abc', '$inputs.grantType': 'code' };
+    const result = interpolate(
+      'client_id={$inputs.clientId}&grant_type={$inputs.grantType}',
+      (expression) => values[expression],
+    );
+    assert.strictEqual(result, 'client_id=abc&grant_type=code');
+  });
+
+  it('should preserve literal content', function () {
+    const result = interpolate('prefix{$url}suffix', () => 'X');
+    assert.strictEqual(result, 'prefixXsuffix');
+  });
+
+  it('should return string with no expressions unchanged', function () {
+    assert.strictEqual(interpolate('no expressions here', () => 'X'), 'no expressions here');
+  });
+
+  it('should return empty string unchanged', function () {
+    assert.strictEqual(interpolate('', () => 'X'), '');
+  });
+
+  it('should interpolate body expressions with JSON pointers', function () {
+    const result = interpolate('{$request.body#/user/uuid}', (expression) => expression);
+    assert.strictEqual(result, '$request.body#/user/uuid');
+  });
+
+  it('should interpolate expressions with JSON pointers in name part', function () {
+    const result = interpolate('pet={$steps.someStepId.outputs.pets#/0/id}', () => 7);
+    assert.strictEqual(result, 'pet=7');
+  });
+
+  describe('default stringification', function () {
+    it('should render undefined as empty string', function () {
+      assert.strictEqual(interpolate('a{$url}b', () => undefined), 'ab');
+    });
+
+    it('should render null as empty string', function () {
+      assert.strictEqual(interpolate('a{$url}b', () => null), 'ab');
+    });
+
+    it('should render strings as-is', function () {
+      assert.strictEqual(interpolate('{$url}', () => 'https://example.com'), 'https://example.com');
+    });
+
+    it('should render numbers via String()', function () {
+      assert.strictEqual(interpolate('{$statusCode}', () => 200), '200');
+    });
+
+    it('should render booleans via String()', function () {
+      assert.strictEqual(interpolate('{$url}', () => true), 'true');
+    });
+
+    it('should render objects via JSON.stringify', function () {
+      assert.strictEqual(interpolate('{$request.body}', () => ({ a: 1 })), '{"a":1}');
+    });
+
+    it('should render arrays via JSON.stringify', function () {
+      assert.strictEqual(interpolate('{$request.body}', () => [1, 2]), '[1,2]');
+    });
+  });
+
+  it('should support a custom stringify option', function () {
+    const result = interpolate('{$request.body}', () => ({ a: 1 }), {
+      stringify: (value) => JSON.stringify(value, null, 2),
+    });
+    assert.strictEqual(result, '{\n  "a": 1\n}');
+  });
+
+  it('should return template unchanged when it cannot be parsed', function () {
+    assert.strictEqual(interpolate('text with } in it', () => 'X'), 'text with } in it');
+    assert.strictEqual(interpolate('{invalid}', () => 'X'), '{invalid}');
+    assert.strictEqual(interpolate('{{$url}}', () => 'X'), '{{$url}}');
+  });
+
+  it('should throw for non-string template', function () {
+    assert.throws(() => interpolate(123, () => 'X'), TypeError);
+    assert.throws(() => interpolate(null, () => 'X'), TypeError);
+  });
+
+  it('should throw when resolver is not a function', function () {
+    assert.throws(() => interpolate('{$url}', 'not a function'), TypeError);
+    assert.throws(() => interpolate('{$url}'), TypeError);
+  });
+});

--- a/test/interpolate.js
+++ b/test/interpolate.js
@@ -97,6 +97,12 @@ describe('interpolate', function () {
     it('should render arrays via JSON.stringify', function () {
       assert.strictEqual(interpolate('{$request.body}', () => [1, 2]), '[1,2]');
     });
+
+    it('should render an unserializable object as empty string', function () {
+      // JSON.stringify returns undefined when toJSON() returns undefined;
+      // it must not leak the literal string "undefined" into the output.
+      assert.strictEqual(interpolate('a{$request.body}b', () => ({ toJSON: () => undefined })), 'ab');
+    });
   });
 
   it('should support a custom stringify option', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -366,6 +366,33 @@ export function test(runtimeExpression: string): boolean;
 export function extract(str: string): string[];
 
 /**
+ * Resolves a single runtime expression to its value during interpolation.
+ */
+export type InterpolateResolver = (expression: string) => unknown;
+
+/**
+ * Interpolation options
+ */
+export interface InterpolateOptions {
+  /**
+   * Converts a resolved value into the string spliced into the template.
+   * Defaults to: '' for undefined/null, strings as-is, JSON.stringify for
+   * objects and String() for everything else.
+   */
+  readonly stringify?: (value: unknown) => string;
+}
+
+/**
+ * Interpolate (transclude) runtime expressions embedded in a template string,
+ * replacing each {expression} with the value produced by the resolver.
+ */
+export function interpolate(
+  template: string,
+  resolver: InterpolateResolver,
+  options?: InterpolateOptions,
+): string;
+
+/**
  * Grammar - ABNF grammar for runtime expressions
  */
 export class Grammar {


### PR DESCRIPTION
## Summary

Implements the transclusion mechanism for string templates (#86) as `interpolate()`.

`interpolate(template, resolver, options?)` renders Arazzo string templates by replacing each embedded `{expression}` with a value produced by a user-supplied `resolver` callback:

```js
import { interpolate } from '@swaggerexpert/arazzo-runtime-expression';

interpolate('Hello {$inputs.name}!', () => 'world'); // => 'Hello world!'

const values = { '$inputs.clientId': 'abc', '$inputs.grantType': 'authorization_code' };
interpolate('client_id={$inputs.clientId}&grant_type={$inputs.grantType}', (expr) => values[expr]);
// => 'client_id=abc&grant_type=authorization_code'
```

## Design

- Reuses the existing `expression-string` grammar/CST (same foundation as `extract`), so expression boundaries — including JSON Pointers in the `name` part — are parsed correctly rather than regex-matched.
- Because this package is a context-agnostic parser, resolution logic is supplied by the caller via `resolver`, which receives the raw expression (e.g. `$inputs.name`). This composes cleanly with a downstream evaluator.
- Resolved values are stringified via a configurable `stringify` option: defaults to `''` for `undefined`/`null`, strings as-is, `JSON.stringify` for objects, `String()` otherwise.
- Throws `TypeError` for non-string templates / non-function resolvers; returns the template unchanged when it can't be parsed (mirroring `extract`'s leniency).

## Changes

- `src/interpolate.js` — implementation
- `src/index.js` — public export
- `types/index.d.ts` — `interpolate`, `InterpolateResolver`, `InterpolateOptions` typings
- `README.md` — new Interpolation section, TOC entry, updated tagline
- `test/interpolate.js` — 19 tests

## Verification

Full `npm run build` succeeds with dual ESM/CJS output; all 188 tests pass; both built formats confirmed to export a working `interpolate`.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)